### PR TITLE
feat(cli): implement argument parsing for source, replica, interval and log #1

### DIFF
--- a/FolderSync/src/FolderSync.App/Cli/ArgsParser.cs
+++ b/FolderSync/src/FolderSync.App/Cli/ArgsParser.cs
@@ -1,0 +1,148 @@
+﻿using System.Globalization;
+using FolderSync.Core.Options;
+
+namespace FolderSync.App.Cli;
+
+public static class ArgsParser
+{
+    private static readonly HashSet<string> Known = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "--source",
+        "--replica",
+        "--interval",
+        "--log",
+        "--help",
+        "-h",
+        "/?"
+    };
+
+    public static bool IsHelpRequested(string[] args) =>
+        args.Any(a => string.Equals(a, "--help", StringComparison.OrdinalIgnoreCase)
+                      || string.Equals(a, "-h", StringComparison.OrdinalIgnoreCase)
+                      || string.Equals(a, "/?", StringComparison.OrdinalIgnoreCase));
+
+
+    public static SyncOptions Parse(string[] args)
+    {
+        if (args.Length == 0)
+            throw new ArgumentException("Brak argumentów. Użyj --help");
+
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            var token = args[i];
+            if (token.StartsWith("--", StringComparison.Ordinal))
+            {
+                if (!Known.Contains(token))
+                    throw new ArgumentException($"Nieznana flaga: {token}");
+
+                if (token.Equals("--help", StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (i + 1 >= args.Length || args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                    throw new ArgumentException($"Flaga {token} wymaga wartości");
+
+                dict[token] = args[++i];
+            }
+            else
+                throw new ArgumentException($"Nieoczekiwany token: {token}. Oczekiwano flag --key value");
+        }
+
+        string source = Require(dict, "--source");
+        string replica = Require(dict, "--replica");
+        string intervalStr = Require(dict, "--interval");
+        string logPath = Require(dict, "--log");
+
+        string normSource = NormalizeExistingDirectory(source, mustExist: true, name: "--source");
+        string normReplica = NormalizeDirectory(replica, name: "--replica");
+        string normLog = NormalizeFilePath(logPath, name: "--log");
+
+        var interval = ParseInterval(intervalStr);
+        if (interval <= TimeSpan.Zero)
+            throw new ArgumentException("--interval musi być dodatni.");
+
+        return new SyncOptions
+        {
+            SourcePath = normSource,
+            ReplicaPath = normReplica,
+            Interval = interval,
+            LogFilePath = normLog,
+        };
+    }
+
+    private static TimeSpan ParseInterval(string value)
+    {
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int seconds))
+        {
+            if (seconds <= 0) throw new ArgumentException("--interval w sekundach musi być > 0");
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var ts))
+            return ts;
+        throw new ArgumentException("Nieprawidłowy format --interval. Użyj liczby sekund lub HH:MM:SS.");
+    }
+
+    private static string Require(Dictionary<string, string> dict, string key)
+    {
+        if (!dict.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"Brak wymaganej flagi {key}");
+        return value.Trim();
+    }
+
+    private static string NormalizeExistingDirectory(string path, bool mustExist, string name)
+    {
+        string full = Path.GetFullPath(path);
+        if (mustExist && !Directory.Exists(full))
+            throw new ArgumentException($"Ścieżka {name} nie istnieje: {full}");
+        return TrimEndingSeparators(full);
+    }
+
+    private static string NormalizeDirectory(string path, string name)
+    {
+        try
+        {
+            string full = Path.GetFullPath(path);
+            return TrimEndingSeparators(full);
+        }
+        catch (Exception ex)
+        {
+            throw new ArgumentException($"Nieprawidłowa ścieżka dla {name}: {path}. {ex.Message}");
+        }
+    }
+
+    private static string NormalizeFilePath(string path, string name)
+    {
+        try
+        {
+            string full = Path.GetFullPath(path);
+            var dir = Path.GetDirectoryName(full);
+            if (string.IsNullOrWhiteSpace(dir))
+                throw new ArgumentException($"{name}: ścieżka pliku musi zawierać katalog nadrzędny");
+            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+            return full;
+        }
+        catch (Exception ex)
+        {
+            throw new ArgumentException($"Nieprawidłowa ścieżka dla {name}: {path}. {ex.Message}");
+        }
+    }
+
+    private static string TrimEndingSeparators(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return path;
+        return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    public static void PrintUsage(TextWriter output)
+    {
+        output.WriteLine(
+            @"Usage:
+            FolderSync --source <dir> --replica <dir> --interval <seconds|HH:MM:SS> --log <file>
+
+            Examples:
+            FolderSync --source C:\Data --replica D:\Mirror --interval 300 --log C:\logs\sync.log
+            FolderSync --source /data --replica /mnt/mirror --interval 00:05:00 --log /var/log/foldersync.log"
+        );
+    }
+}

--- a/FolderSync/src/FolderSync.App/ExitCode.cs
+++ b/FolderSync/src/FolderSync.App/ExitCode.cs
@@ -1,0 +1,8 @@
+﻿namespace FolderSync.App;
+
+public enum ExitCode
+{
+    Success = 0,
+    InvalidArguments = 2,
+    UnhandledException = 10,
+}

--- a/FolderSync/src/FolderSync.App/Program.cs
+++ b/FolderSync/src/FolderSync.App/Program.cs
@@ -1,2 +1,26 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+﻿using FolderSync.App;
+using FolderSync.App.Cli;
+using FolderSync.Core.Options;
+
+try
+{
+    if (ArgsParser.IsHelpRequested(args))
+    {
+        ArgsParser.PrintUsage(Console.Out);
+        return (int)ExitCode.Success;
+    }
+
+    SyncOptions opts = ArgsParser.Parse(args);
+    
+    Console.WriteLine("Argumenty Ok. Znormalizowane wartości:");
+    Console.WriteLine(opts.ToString());
+
+    return (int)ExitCode.Success;
+}
+catch (ArgumentException ex)
+{
+    await Console.Error.WriteLineAsync($"BŁĄD ARGUMENTÓW: {ex.Message}");
+    await Console.Error.WriteLineAsync();
+    ArgsParser.PrintUsage(Console.Error);
+    return (int)ExitCode.InvalidArguments;
+}

--- a/FolderSync/src/FolderSync.Core/Options/SyncOptions.cs
+++ b/FolderSync/src/FolderSync.Core/Options/SyncOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace FolderSync.Core.Options;
+
+public sealed class SyncOptions
+{
+    public required string SourcePath { get; init; }
+    public required string ReplicaPath { get; init; }
+    public required TimeSpan Interval { get; init; }
+    public required string LogFilePath { get; set; }
+    
+    public override string ToString() =>
+        $"Source={SourcePath}, Replica={ReplicaPath}, Interval={Interval}, Log={LogFilePath}";
+}


### PR DESCRIPTION
Added ArgsParser in FolderSync.App with validation and normalization of CLI arguments:
- required flags: --source, --replica, --interval, --log
- support for --help, -h, /?
- interval parsing (seconds or TimeSpan)
- path normalization and validation
- exit codes: 0 (success), 2 (invalid args), 10 (unexpected error)

Introduced SyncOptions model in FolderSync.Core.Options and ExitCode enum in FolderSync.App.