### PR TITLE
feat(copy): add atomic file copy/update and directory creation (#5)

### DIFF
--- a/FolderSync/src/FolderSync.App/Program.cs
+++ b/FolderSync/src/FolderSync.App/Program.cs
@@ -1,5 +1,6 @@
 ﻿using FolderSync.App;
 using FolderSync.App.Cli;
+using FolderSync.Core.Copying;
 using FolderSync.Core.Diff;
 using FolderSync.Core.Logging;
 using FolderSync.Core.Options;
@@ -26,8 +27,10 @@ try
     var sourceSnap = await scanner.BuildSnapshotAsync(opts.SourcePath);
     var replicaSnap = await scanner.BuildSnapshotAsync(opts.ReplicaPath);
     var engine = new DiffEngine(loggerFactory.CreateLogger<DiffEngine>());
-    engine.Compute(sourceSnap, replicaSnap);
-
+    var diffResult = engine.Compute(sourceSnap, replicaSnap);
+    var copyEngine = new CopyEngine(loggerFactory.CreateLogger<CopyEngine>());
+    await copyEngine.ApplyAsync(sourceSnap, replicaSnap, diffResult);
+    
     return (int)ExitCode.Success;
 }
 catch (ArgumentException ex)

--- a/FolderSync/src/FolderSync.Core/Abstractions/PathHelpers.cs
+++ b/FolderSync/src/FolderSync.Core/Abstractions/PathHelpers.cs
@@ -1,0 +1,16 @@
+﻿namespace FolderSync.Core.Abstractions;
+
+public static class PathHelpers
+{
+    public static string CombineUnderRoot(string root, string relative)
+    {
+        return Path.Combine(root, relative);
+    }
+
+    public static void EnsureDirectoryForFile(string fullFilePath)
+    {
+        var dir = Path.GetDirectoryName(fullFilePath);
+        if(!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+    }
+}

--- a/FolderSync/src/FolderSync.Core/Copying/CopyEngine.cs
+++ b/FolderSync/src/FolderSync.Core/Copying/CopyEngine.cs
@@ -1,0 +1,99 @@
+﻿using FolderSync.Core.Abstractions;
+using FolderSync.Core.Diff;
+using FolderSync.Core.Scanning;
+using Microsoft.Extensions.Logging;
+
+namespace FolderSync.Core.Copying;
+
+public class CopyEngine
+{
+    private readonly ILogger<CopyEngine> _logger;
+    private const string TempSuffix = ".fs_temp";
+
+    public CopyEngine(ILogger<CopyEngine> logger) => _logger = logger;
+
+    public async Task ApplyAsync(DirectorySnapshot source, DirectorySnapshot replica, DiffResult diff,
+        CancellationToken ct = default)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (replica is null) throw new ArgumentNullException(nameof(replica));
+        if (diff is null) throw new ArgumentNullException(nameof(diff));
+
+
+        foreach (var relDir in diff.DirsToCreate)
+        {
+            ct.ThrowIfCancellationRequested();
+            var targetDir = PathHelpers.CombineUnderRoot(replica.RootPath, relDir);
+            try
+            {
+                Directory.CreateDirectory(targetDir);
+                _logger.LogInformation("Created directory: {Dir}", targetDir);
+            }
+            catch (Exception ex) when (IsBenignIo(ex))
+            {
+                _logger.LogWarning(ex, "Failed to create directory: {Dir}", targetDir);
+            }
+        }
+
+        foreach (var relFile in diff.FilesToCopy)
+        {
+            ct.ThrowIfCancellationRequested();
+            var src = PathHelpers.CombineUnderRoot(source.RootPath, relFile);
+            var dst = PathHelpers.CombineUnderRoot(replica.RootPath, relFile);
+
+            try
+            {
+                await AtomicCopyAsync(src, dst, ct).ConfigureAwait(false);
+                var ts = source.Files[relFile].LastWriteTimeUtc;
+                File.SetLastWriteTimeUtc(dst, ts);
+                _logger.LogInformation("Copied: {Rel} -> {Dst}", relFile, dst);
+            }
+            catch (Exception ex) when (IsBenignIo(ex))
+            {
+                _logger.LogError(ex, "Failed to copy file: {Src} -> {Dst}", src, dst);
+            }
+        }
+
+        foreach (var relFile in diff.FilesToUpdate)
+        {
+            ct.ThrowIfCancellationRequested();
+            var src = PathHelpers.CombineUnderRoot(source.RootPath, relFile);
+            var dst = PathHelpers.CombineUnderRoot(replica.RootPath, relFile);
+            try
+            {
+                await AtomicCopyAsync(src, dst, ct).ConfigureAwait(false);
+                var ts = source.Files[relFile].LastWriteTimeUtc;
+                File.SetLastWriteTimeUtc(dst, ts);
+                _logger.LogInformation("Updated: {Rel} -> {Dst}", relFile, dst);
+            }
+            catch (Exception ex) when (IsBenignIo(ex))
+            {
+                _logger.LogError(ex, "Failed to update file: {Src} -> {Dst}", src, dst);
+            }
+        }
+    }
+
+    private static async Task AtomicCopyAsync(string sourceFile, string destinationFile, CancellationToken ct)
+    {
+        PathHelpers.EnsureDirectoryForFile(destinationFile);
+
+        var tempFile = destinationFile + TempSuffix + "." + Guid.NewGuid().ToString("N");
+
+        using (var src = new FileStream(sourceFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (var dst = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            await src.CopyToAsync(dst, ct).ConfigureAwait(false);
+        }
+
+        if (File.Exists(destinationFile))
+            File.Replace(tempFile, destinationFile, destinationBackupFileName: null, ignoreMetadataErrors: true);
+        else
+            File.Move(tempFile, destinationFile);
+    }
+
+    private static bool IsBenignIo(Exception ex) => ex is IOException
+                                                    || ex is UnauthorizedAccessException
+                                                    || ex is DirectoryNotFoundException
+                                                    || ex is FileNotFoundException
+                                                    || ex is PathTooLongException;
+}


### PR DESCRIPTION
- Implemented CopyEngine to apply diff operations (copy/update) with atomic replace
- Preserved LastWriteTimeUtc to avoid unnecessary re-syncs
- Added PathHelpers for path composition and directory creation
- Logged each operation and handled benign IO errors