### PR TITLE
fix(metadata): use actual LastWriteTimeUtc instead of DateTime.MinValue

### DIFF
--- a/FolderSync/src/FolderSync.Core/Scanning/DirectoryScanner.cs
+++ b/FolderSync/src/FolderSync.Core/Scanning/DirectoryScanner.cs
@@ -53,7 +53,7 @@ public sealed class DirectoryScanner : IDirectoryScanner
                     {
                         var fi = new FileInfo(file);
                         var meta = new FileMetadata(Size: fi.Exists ? fi.Length : 0L,
-                            LastWriteTimeUtc: DateTime.MinValue);
+                            LastWriteTimeUtc: fi.LastWriteTimeUtc);
                         var relFile = ToRelative(rootPath, file);
                         files[relFile] = meta;
                     }


### PR DESCRIPTION
Previously, FileMetadata.LastWriteTimeUtc was always set to DateTime.MinValue, which resulted in incorrect file modification times. Now it uses fi.LastWriteTimeUtc to correctly capture the last write time of each file.